### PR TITLE
add step to create secret sshpublickey

### DIFF
--- a/templates/docs/kops.md
+++ b/templates/docs/kops.md
@@ -140,7 +140,13 @@ Then run this command to write the state to the S3 state storage bucket. This wo
 make kops/create
 ```
 
-Run the following command to provision the AWS resources for the cluster:
+Next, provision the SSH Public Key Secret:
+
+```bash
+make kops/create-secret-sshpublickey`
+```
+
+Finally, run the following command to provision the AWS resources for the cluster:
 
 ```bash
 kops update cluster --yes


### PR DESCRIPTION
Addresses this error: ```SSH public key must be specified when running with AWS (create with `kops create secret --name us-west-2.staging.acme.co sshpublickey admin -i ~/.ssh/id_rsa.pub`)```

This step is also documented in https://github.com/cloudposse/terraform-root-modules/blob/master/aws/kops/README.md