### PR TITLE
Create terraform.tfvars

### DIFF
--- a/templates/conf/tfstate-backend/terraform.tfvars
+++ b/templates/conf/tfstate-backend/terraform.tfvars
@@ -1,1 +1,1 @@
-aws_region = "${aws_region}"
+region = "${aws_region}"

--- a/templates/conf/tfstate-backend/terraform.tfvars
+++ b/templates/conf/tfstate-backend/terraform.tfvars
@@ -1,0 +1,1 @@
+aws_region = "${aws_region}"


### PR DESCRIPTION
## What

Creates a "templates/conf/tfstate-backend/terraform.tfvars file which defines the aws_region = "${aws_region}"."

## Why

As per #7, "this is going to block ANYONE using reference-architectures that is not in us-west-2!" inside of `root.tfvars`:
```
# The default region for this account
aws_region = "eu-west-2"
```