### PR TITLE
Make tfstate-backend variable file to be copied to templates

### DIFF
--- a/configs/corp.tfvars
+++ b/configs/corp.tfvars
@@ -16,6 +16,7 @@ templates = [
   "Makefile",
   "conf/Makefile",
   "conf/account-dns/terraform.tfvars",
+  "conf/tfstate-backend/terraform.tfvars",
   "docs/kops.md",
 ]
 

--- a/configs/data.tfvars
+++ b/configs/data.tfvars
@@ -16,6 +16,7 @@ templates = [
   "Makefile",
   "conf/Makefile",
   "conf/account-dns/terraform.tfvars",
+  "conf/tfstate-backend/terraform.tfvars",
   "docs/kops.md",
 ]
 

--- a/configs/dev.tfvars
+++ b/configs/dev.tfvars
@@ -16,6 +16,7 @@ templates = [
   "Makefile",
   "conf/Makefile",
   "conf/account-dns/terraform.tfvars",
+  "conf/tfstate-backend/terraform.tfvars",
 ]
 
 # List of terraform root modules to enable

--- a/configs/prod.tfvars
+++ b/configs/prod.tfvars
@@ -16,6 +16,7 @@ templates = [
   "Makefile",
   "conf/Makefile",
   "conf/account-dns/terraform.tfvars",
+  "conf/tfstate-backend/terraform.tfvars",
   "docs/kops.md",
 ]
 

--- a/configs/root.tfvars
+++ b/configs/root.tfvars
@@ -38,6 +38,7 @@ templates = [
   "conf/bootstrap/terraform.tfvars",
   "conf/iam/terraform.tfvars",
   "conf/root-dns/terraform.tfvars",
+  "conf/tfstate-backend/terraform.tfvars",
   "conf/users/terraform.tfvars"
 ]
 

--- a/configs/staging.tfvars
+++ b/configs/staging.tfvars
@@ -16,6 +16,7 @@ templates = [
   "Makefile",
   "conf/Makefile",
   "conf/account-dns/terraform.tfvars",
+  "conf/tfstate-backend/terraform.tfvars",
   "docs/kops.md",
 ]
 

--- a/configs/testing.tfvars
+++ b/configs/testing.tfvars
@@ -16,6 +16,7 @@ templates = [
   "Makefile",
   "conf/Makefile",
   "conf/account-dns/terraform.tfvars",
+  "conf/tfstate-backend/terraform.tfvars",
   "docs/kops.md",
 ]
 


### PR DESCRIPTION
## what
* Include the varfile

## why
* While testing https://github.com/cloudposse/reference-architectures/pull/15 I forgot, that I made a tiny change while testing, because I missed how exactly the build happens.
* We have to also copy the terraform file to the different configs, to include it in the Docker images.