### PR TITLE
[kops] Add support for running kubernetes cluster in existing VPC

### DIFF
--- a/configs/root.tfvars
+++ b/configs/root.tfvars
@@ -15,7 +15,9 @@ org_network_offset  = 100
 org_network_newbits = 8    # /8 + /8 = /16
 
 # Pod IP address space (must not overlap with org_network_cidr)
-kops_non_masquerade_cidr = "172.16.0.0/12"
+# 100.64.0.0/10 is the default used by kops, even though it is technically reserved for carrier-grade NAT
+# See https://github.com/cloudposse/docs/issues/455
+kops_non_masquerade_cidr = "100.64.0.0/10"
 
 
 # The docker registry that will be used for the images built (nothing will get pushed)

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -2,7 +2,9 @@ export DOCKER_ORG ?= ${docker_registry}
 export DOCKER_IMAGE ?= $(DOCKER_ORG)/${image_name}
 export DOCKER_TAG ?= latest
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
-export DOCKER_BUILD_FLAGS = --pull
+# If you do not want to use locally built Geodesic images ever, then you can uncomment the line below
+# DOCKER_BUILD_FLAGS = --pull ensures that local images will never be used for your build
+# export DOCKER_BUILD_FLAGS = --pull
 export README_DEPS ?= docs/targets.md docs/terraform.md
 export INSTALL_PATH ?= /usr/local/bin
 export SCRIPT ?= $(notdir $(DOCKER_IMAGE))

--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -55,14 +55,12 @@ spec:
   {{- if bool (getenv "KOPS_AUTHORIZATION_RBAC_ENABLED" "false") }}
     anonymousAuth: false
     authorizationMode: {{ getenv "KOPS_KUBE_API_SERVER_AUTHORIZATION_MODE" "RBAC" }}
-    authorizationRbacSuperUser: {{ getenv "KOPS_KUBE_API_SERVER_AUTHORIZATION_RBAC_SUPER_USER" "admin" }}
   {{- end }}
   {{- if bool (getenv "KOPS_ADMISSION_CONTROL_ENABLED" "true") }}
     admissionControl:
     - NamespaceLifecycle
     - LimitRanger
     - ServiceAccount
-    - PersistentVolumeLabel
     - DefaultStorageClass
     - DefaultTolerationSeconds
     - MutatingAdmissionWebhook
@@ -201,6 +199,9 @@ spec:
   kubernetesVersion: {{ getenv "KUBERNETES_VERSION" }}
   masterPublicName: api.{{ getenv "KOPS_CLUSTER_NAME" }}
   networkCIDR: {{ getenv "KOPS_NETWORK_CIDR" "172.20.0.0/16" }}
+  {{- if getenv "KOPS_CONFIGURED_VPC_ID" }}
+  networkID: {{ getenv "KOPS_CONFIGURED_VPC_ID" }}
+  {{- end }}
   networking:
     calico: {}
   nonMasqueradeCIDR: {{ getenv "KOPS_NON_MASQUERADE_CIDR" "100.64.0.0/10" }}
@@ -208,17 +209,32 @@ spec:
   - 0.0.0.0/0
   subnets:
   {{- range $index, $value := (getenv "KOPS_AVAILABILITY_ZONES" | strings.Split ",") }}
-  {{- $privateSubnets := getenv "KOPS_PRIVATE_SUBNETS" }}
+  {{- $privateSubnets := getenv "KOPS_PRIVATE_SUBNETS" | required "KOPS_PRIVATE_SUBNETS must be defined" }}
+  {{- $privateSubnetIDs := getenv "KOPS_CONFIGURED_PRIVATE_SUBNET_IDS" }}
+  {{- $natGateways := getenv "KOPS_CONFIGURED_NAT_GATEWAYS" }}
   {{- $subnet := strings.Split "," $privateSubnets }}
+  {{- $subnetID := strings.Split "," $privateSubnetIDs }}
+  {{- $nat := strings.Split "," $natGateways }}
   - cidr: {{ index $subnet $index }}
+    {{- if $privateSubnetIDs }}
+    id: {{ index $subnetID $index }}
+    {{- end }}
     name: {{ $value }}
+    {{- if $natGateways }}
+    egress: {{ index $nat $index }}
+    {{- end }}
     type: Private
     zone: {{ $value }}
   {{- end }}
   {{- range $index, $value := (getenv "KOPS_AVAILABILITY_ZONES" | strings.Split ",") }}
   {{- $utilitySubnets := getenv "KOPS_UTILITY_SUBNETS" }}
+  {{- $utilitySubnetIDs := getenv "KOPS_CONFIGURED_UTILITY_SUBNET_IDS" }}
   {{- $subnet := strings.Split "," $utilitySubnets }}
+  {{- $subnetID := strings.Split "," $utilitySubnetIDs }}
   - cidr: {{ index $subnet $index }}
+    {{- if $utilitySubnetIDs }}
+    id: {{ index $subnetID $index }}
+    {{- end }}
     name: utility-{{ $value }}
     type: Utility
     zone: {{ $value }}

--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -199,8 +199,8 @@ spec:
   kubernetesVersion: {{ getenv "KUBERNETES_VERSION" }}
   masterPublicName: api.{{ getenv "KOPS_CLUSTER_NAME" }}
   networkCIDR: {{ getenv "KOPS_NETWORK_CIDR" "172.20.0.0/16" }}
-  {{- if getenv "KOPS_CONFIGURED_VPC_ID" }}
-  networkID: {{ getenv "KOPS_CONFIGURED_VPC_ID" }}
+  {{- if getenv "KOPS_SHARED_VPC_ID" }}
+  networkID: {{ getenv "KOPS_SHARED_VPC_ID" }}
   {{- end }}
   networking:
     calico: {}
@@ -210,8 +210,8 @@ spec:
   subnets:
   {{- range $index, $value := (getenv "KOPS_AVAILABILITY_ZONES" | strings.Split ",") }}
   {{- $privateSubnets := getenv "KOPS_PRIVATE_SUBNETS" | required "KOPS_PRIVATE_SUBNETS must be defined" }}
-  {{- $privateSubnetIDs := getenv "KOPS_CONFIGURED_PRIVATE_SUBNET_IDS" }}
-  {{- $natGateways := getenv "KOPS_CONFIGURED_NAT_GATEWAYS" }}
+  {{- $privateSubnetIDs := getenv "KOPS_SHARED_PRIVATE_SUBNET_IDS" }}
+  {{- $natGateways := getenv "KOPS_SHARED_NAT_GATEWAYS" }}
   {{- $subnet := strings.Split "," $privateSubnets }}
   {{- $subnetID := strings.Split "," $privateSubnetIDs }}
   {{- $nat := strings.Split "," $natGateways }}
@@ -228,7 +228,7 @@ spec:
   {{- end }}
   {{- range $index, $value := (getenv "KOPS_AVAILABILITY_ZONES" | strings.Split ",") }}
   {{- $utilitySubnets := getenv "KOPS_UTILITY_SUBNETS" }}
-  {{- $utilitySubnetIDs := getenv "KOPS_CONFIGURED_UTILITY_SUBNET_IDS" }}
+  {{- $utilitySubnetIDs := getenv "KOPS_SHARED_UTILITY_SUBNET_IDS" }}
   {{- $subnet := strings.Split "," $utilitySubnets }}
   {{- $subnetID := strings.Split "," $utilitySubnetIDs }}
   - cidr: {{ index $subnet $index }}


### PR DESCRIPTION
## what
- Add support for running the kubernetes cluster in a pre-existing VPC
- Update `kops-private-topology.yaml.gotmpl` to be compatible with kubernetes v 1.12
- Switch to kops default non-masquerade CIDR
- Update Makefile to allow for building images based on local images
## why
- Make it easier to have all services in one VPC
- Use kubernetes 1.12 rather than 1.11
- Avoid conflicts such as with Docker's default network
- Allow developers to develop locally