### PR TITLE
[kops] Switch from kube-dns to CoreDNS, do not install cluster autoscaler by default

### DIFF
--- a/templates/conf/helmfiles/helmfile.envrc
+++ b/templates/conf/helmfiles/helmfile.envrc
@@ -25,9 +25,6 @@ export NGINX_INGRESS_KIND=DaemonSet
 # IAM role for aws alb ingress controller
 export AWS_ALB_INGRESS_CONTROLLER_IAM_ROLE_NAME=${NAMESPACE}-${STAGE}-alb-ingress
 
-# Autoscaling not necessary at this time
-export KOPS_CLUSTER_AUTOSCALER_ENABLED=false
-
 export GRAFANA_INGRESS_ENABLED=false
 # GRAFANA_HOSTNAME is required if INGRESS is enabled
 #export GRAFANA_HOSTNAME=
@@ -43,7 +40,6 @@ export KUBERNETES_DASHBOARD_INGRESS_TLS_ENABLED=false
 export RELOADER_INSTALLED=true
 export CERT_MANAGER_INSTALLED=true
 export PROMETHEUS_OPERATOR_INSTALLED=true
-export CLUSTER_AUTOSCALER_INSTALLED=true
 export KIAM_INSTALLED=true
 export EXTERNAL_DNS_INSTALLED=true
 export AWS_ALB_INGRESS_CONTROLLER_INSTALLED=true

--- a/templates/conf/helmfiles/helmfile.yaml
+++ b/templates/conf/helmfiles/helmfile.yaml
@@ -1,7 +1,6 @@
 # Ordered list of releases. 
 helmfiles:
   - "releases/prometheus-operator.yaml"
-  - "releases/cluster-autoscaler.yaml"
   - "releases/kiam.yaml"
   - "releases/external-dns.yaml"
   - "releases/kube-lego.yaml"

--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -198,6 +198,8 @@ spec:
           --query 'Tags[*].{tag:Key,value:Value}' \
           --output text | sed 's/\t/=/' | grep k8s.io/role | sed 's%k8s.io/role/%%' | cut -f1 -d=
 {{- end }}
+  kubeDNS:
+    provider: CoreDNS
 {{- if bool (getenv "KOPS_AUTHORIZATION_RBAC_ENABLED" "false") }}
   kubelet:
     anonymousAuth: false


### PR DESCRIPTION
## what
- [kops] Switch from kube-dns to CoreDNS
- [kops] do not install cluster autoscaler by default
## why
- CoreDNS is the newer replacement for kube-dns. In addition, "there are several open issues with kube-dns that are resolved in CoreDNS" See https://kubernetes.io/blog/2018/07/10/coredns-ga-for-kubernetes-cluster-dns/
- cluster autoscaler is complex to configure and not required for most installations