### PR TITLE
Different configs for Masters and Nodes AZs

### DIFF
--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -283,7 +283,7 @@ spec:
   - utility-{{ . }}
   {{- end }}
 
-{{ range (getenv "KOPS_AVAILABILITY_ZONES" | strings.Split ",") }}
+{{ range (getenv "KOPS_MASTERS_AVAILABILITY_ZONES" ( getenv "KOPS_AVAILABILITY_ZONES" ) | strings.Split ",") }}
 
 ---
 apiVersion: kops/v1alpha2
@@ -320,7 +320,7 @@ spec:
   minSize: {{ getenv "NODE_MIN_SIZE" }}
   role: Node
   subnets:
-  {{- range (getenv "KOPS_AVAILABILITY_ZONES" | strings.Split ",") }}
+  {{- range (getenv "KOPS_NODES_AVAILABILITY_ZONES" ( getenv "KOPS_AVAILABILITY_ZONES" ) | strings.Split ",") }}
   - {{ . }}
   {{- end }}
 


### PR DESCRIPTION
## What
* Made ability to override availability zone for masters\nodes

## Why
* To have 3 zones masters and 2 zones nodes