### PR TITLE
module paths

### DIFF
--- a/configs/audit.tfvars
+++ b/configs/audit.tfvars
@@ -31,7 +31,7 @@ templates = [
   "conf/audit-cloudtrail/terraform.envrc",
 ]
 
-# List of terraform root modules to enable
+# Map of terraform root modules to enable
 terraform_root_modules = {
   "aws/tfstate-backend"  = "/conf/tfstate-backend"
   "aws/account-dns"      = "/conf/account-dns"

--- a/configs/audit.tfvars
+++ b/configs/audit.tfvars
@@ -33,8 +33,8 @@ templates = [
 
 # List of terraform root modules to enable
 terraform_root_modules = {
-  "aws/tfstate-backend" => "/conf/tfstate-backend",
-  "aws/account-dns" => "/conf/account-dns",
-  "aws/chamber" => "/conf/chamber",
-  "aws/audit-cloudtrail" => "/conf/audit-cloudtrail",
+  "aws/tfstate-backend"  = "/conf/tfstate-backend"
+  "aws/account-dns"      = "/conf/account-dns"
+  "aws/chamber"          = "/conf/chamber"
+  "aws/audit-cloudtrail" = "/conf/audit-cloudtrail"
 }

--- a/configs/audit.tfvars
+++ b/configs/audit.tfvars
@@ -32,9 +32,9 @@ templates = [
 ]
 
 # List of terraform root modules to enable
-terraform_root_modules = [
-  "aws/tfstate-backend",
-  "aws/account-dns",
-  "aws/chamber",
-  "aws/audit-cloudtrail",
-]
+terraform_root_modules = {
+  "aws/tfstate-backend" => "/conf/tfstate-backend",
+  "aws/account-dns" => "/conf/account-dns",
+  "aws/chamber" => "/conf/chamber",
+  "aws/audit-cloudtrail" => "/conf/audit-cloudtrail",
+}

--- a/configs/corp.tfvars
+++ b/configs/corp.tfvars
@@ -43,10 +43,10 @@ templates = [
 
 # List of terraform root modules to enable
 terraform_root_modules = {
-  "aws/tfstate-backend" => "/conf/tfstate-backend",
-  "aws/account-dns" => "/conf/account-dns",
-  "aws/chamber" => "/conf/chamber",
-  "aws/kops" => "/conf/kops",
-  "aws/kops-aws-platform" => "/conf/kops-aws-platform",
-  "aws/cloudtrail" => "/conf/cloudtrail",
+  "aws/tfstate-backend"   = "/conf/tfstate-backend"
+  "aws/account-dns"       = "/conf/account-dns"
+  "aws/chamber"           = "/conf/chamber"
+  "aws/kops"              = "/conf/kops"
+  "aws/kops-aws-platform" = "/conf/kops-aws-platform"
+  "aws/cloudtrail"        = "/conf/cloudtrail"
 }

--- a/configs/corp.tfvars
+++ b/configs/corp.tfvars
@@ -42,11 +42,11 @@ templates = [
 ]
 
 # List of terraform root modules to enable
-terraform_root_modules = [
-  "aws/tfstate-backend",
-  "aws/account-dns",
-  "aws/chamber",
-  "aws/kops",
-  "aws/kops-aws-platform",
-  "aws/cloudtrail",
-]
+terraform_root_modules = {
+  "aws/tfstate-backend" => "/conf/tfstate-backend",
+  "aws/account-dns" => "/conf/account-dns",
+  "aws/chamber" => "/conf/chamber",
+  "aws/kops" => "/conf/kops",
+  "aws/kops-aws-platform" => "/conf/kops-aws-platform",
+  "aws/cloudtrail" => "/conf/cloudtrail",
+}

--- a/configs/corp.tfvars
+++ b/configs/corp.tfvars
@@ -41,7 +41,7 @@ templates = [
   "conf/kops-aws-platform/terraform.tfvars",
 ]
 
-# List of terraform root modules to enable
+# Map of terraform root modules to enable
 terraform_root_modules = {
   "aws/tfstate-backend"   = "/conf/tfstate-backend"
   "aws/account-dns"       = "/conf/account-dns"

--- a/configs/data.tfvars
+++ b/configs/data.tfvars
@@ -43,10 +43,10 @@ templates = [
 
 # List of terraform root modules to enable
 terraform_root_modules = {
-  "aws/tfstate-backend" => "/conf/tfstate-backend",
-  "aws/account-dns" => "/conf/account-dns",
-  "aws/chamber" => "/conf/chamber",
-  "aws/kops" => "/conf/kops",
-  "aws/kops-aws-platform" => "/conf/kops-aws-platform",
-  "aws/cloudtrail" => "/conf/cloudtrail",
+  "aws/tfstate-backend"   = "/conf/tfstate-backend"
+  "aws/account-dns"       = "/conf/account-dns"
+  "aws/chamber"           = "/conf/chamber"
+  "aws/kops"              = "/conf/kops"
+  "aws/kops-aws-platform" = "/conf/kops-aws-platform"
+  "aws/cloudtrail"        = "/conf/cloudtrail"
 }

--- a/configs/data.tfvars
+++ b/configs/data.tfvars
@@ -42,11 +42,11 @@ templates = [
 ]
 
 # List of terraform root modules to enable
-terraform_root_modules = [
-  "aws/tfstate-backend",
-  "aws/account-dns",
-  "aws/chamber",
-  "aws/kops",
-  "aws/kops-aws-platform",
-  "aws/cloudtrail",
-]
+terraform_root_modules = {
+  "aws/tfstate-backend" => "/conf/tfstate-backend",
+  "aws/account-dns" => "/conf/account-dns",
+  "aws/chamber" => "/conf/chamber",
+  "aws/kops" => "/conf/kops",
+  "aws/kops-aws-platform" => "/conf/kops-aws-platform",
+  "aws/cloudtrail" => "/conf/cloudtrail",
+}

--- a/configs/data.tfvars
+++ b/configs/data.tfvars
@@ -41,7 +41,7 @@ templates = [
   "conf/kops-aws-platform/terraform.tfvars",
 ]
 
-# List of terraform root modules to enable
+# Map of terraform root modules to enable
 terraform_root_modules = {
   "aws/tfstate-backend"   = "/conf/tfstate-backend"
   "aws/account-dns"       = "/conf/account-dns"

--- a/configs/dev.tfvars
+++ b/configs/dev.tfvars
@@ -31,7 +31,7 @@ templates = [
   "conf/cloudtrail/terraform.envrc",
 ]
 
-# List of terraform root modules to enable
+# Map of terraform root modules to enable
 terraform_root_modules = [
   "aws/tfstate-backend",
   "aws/account-dns",

--- a/configs/prod.tfvars
+++ b/configs/prod.tfvars
@@ -41,7 +41,7 @@ templates = [
   "conf/kops-aws-platform/terraform.tfvars",
 ]
 
-# List of terraform root modules to enable
+# Map of terraform root modules to enable
 terraform_root_modules = [
   "aws/tfstate-backend",
   "aws/account-dns",

--- a/configs/root.tfvars
+++ b/configs/root.tfvars
@@ -10,15 +10,16 @@ namespace = "test"
 aws_region = "us-west-2"
 
 # Network CIDR of Organization
-org_network_cidr    = "10.0.0.0/8"
-org_network_offset  = 100
-org_network_newbits = 8    # /8 + /8 = /16
+org_network_cidr = "10.0.0.0/8"
+
+org_network_offset = 100
+
+org_network_newbits = 8 # /8 + /8 = /16
 
 # Pod IP address space (must not overlap with org_network_cidr)
 # 100.64.0.0/10 is the default used by kops, even though it is technically reserved for carrier-grade NAT
 # See https://github.com/cloudposse/docs/issues/455
 kops_non_masquerade_cidr = "100.64.0.0/10"
-
 
 # The docker registry that will be used for the images built (nothing will get pushed)
 docker_registry = "cloudposse"
@@ -68,7 +69,7 @@ templates = [
   "conf/users/.envrc",
   "conf/users/Makefile.tasks",
   "conf/users/terraform.envrc",
-  "conf/users/terraform.tfvars"
+  "conf/users/terraform.tfvars",
 ]
 
 # Account email address format (e.g. `ops+%s@example.co`). This is not easily changed later.
@@ -87,7 +88,7 @@ accounts_enabled = [
 
 # Administrator IAM usernames mapped to their keybase usernames for password encryption
 users = {
-#  "erik@cloudposse.com" = "osterman"
+  #  "erik@cloudposse.com" = "osterman"
 }
 
 # Geodesic Base Image (don't change this unless you know what you're doing)
@@ -96,15 +97,15 @@ geodesic_base_image = "cloudposse/geodesic:0.87.0"
 
 # List of terraform root modules to enable
 terraform_root_modules = {
-  "aws/tfstate-backend" => "/conf/tfstate-backend", 
-  "aws/accounts" => "/conf/accounts",
-  "aws/account-settings" => "/conf/account-settings",
-  "aws/bootstrap" => "/conf/bootstrap",
-  "aws/root-dns" => "/conf/root-dns",
-  "aws/root-iam" => "/conf/root-iam",
-  "aws/iam" => "/conf/iam",
-  "aws/users" => "/conf/users",
-  "aws/cloudtrail" => "/conf/cloudtrail",
+  "aws/tfstate-backend"  = "/conf/tfstate-backend"
+  "aws/accounts"         = "/conf/accounts"
+  "aws/account-settings" = "/conf/account-settings"
+  "aws/bootstrap"        = "/conf/bootstrap"
+  "aws/root-dns"         = "/conf/root-dns"
+  "aws/root-iam"         = "/conf/root-iam"
+  "aws/iam"              = "/conf/iam"
+  "aws/users"            = "/conf/users"
+  "aws/cloudtrail"       = "/conf/cloudtrail"
 }
 
 # Message of the Day

--- a/configs/root.tfvars
+++ b/configs/root.tfvars
@@ -95,17 +95,17 @@ users = {
 geodesic_base_image = "cloudposse/geodesic:0.87.0"
 
 # List of terraform root modules to enable
-terraform_root_modules = [
-  "aws/tfstate-backend",
-  "aws/accounts",
-  "aws/account-settings",
-  "aws/bootstrap",
-  "aws/root-dns",
-  "aws/root-iam",
-  "aws/iam",
-  "aws/users",
-  "aws/cloudtrail",
-]
+terraform_root_modules = {
+  "aws/tfstate-backend" => "/conf/tfstate-backend", 
+  "aws/accounts" => "/conf/accounts",
+  "aws/account-settings" => "/conf/account-settings",
+  "aws/bootstrap" => "/conf/bootstrap",
+  "aws/root-dns" => "/conf/root-dns",
+  "aws/root-iam" => "/conf/root-iam",
+  "aws/iam" => "/conf/iam",
+  "aws/users" => "/conf/users",
+  "aws/cloudtrail" => "/conf/cloudtrail",
+}
 
 # Message of the Day
 motd_url = "https://geodesic.sh/motd"

--- a/configs/root.tfvars
+++ b/configs/root.tfvars
@@ -95,7 +95,7 @@ users = {
 # Project: https://github.com/cloudposse/geodesic
 geodesic_base_image = "cloudposse/geodesic:0.87.0"
 
-# List of terraform root modules to enable
+# Map of terraform root modules to enable
 terraform_root_modules = {
   "aws/tfstate-backend"  = "/conf/tfstate-backend"
   "aws/accounts"         = "/conf/accounts"

--- a/configs/staging.tfvars
+++ b/configs/staging.tfvars
@@ -43,10 +43,10 @@ templates = [
 
 # List of terraform root modules to enable
 terraform_root_modules = {
-  "aws/tfstate-backend" => "/conf/tfstate-backend",
-  "aws/account-dns" => "/conf/account-dns",
-  "aws/chamber" => "/conf/chamber",
-  "aws/kops" => "/conf/kops",
-  "aws/kops-aws-platform" => "/conf/kops-aws-platform",
-  "aws/cloudtrail" => "/conf/cloudtrail",
+  "aws/tfstate-backend"   = "/conf/tfstate-backend"
+  "aws/account-dns"       = "/conf/account-dns"
+  "aws/chamber"           = "/conf/chamber"
+  "aws/kops"              = "/conf/kops"
+  "aws/kops-aws-platform" = "/conf/kops-aws-platform"
+  "aws/cloudtrail"        = "/conf/cloudtrail"
 }

--- a/configs/staging.tfvars
+++ b/configs/staging.tfvars
@@ -42,11 +42,11 @@ templates = [
 ]
 
 # List of terraform root modules to enable
-terraform_root_modules = [
-  "aws/tfstate-backend",
-  "aws/account-dns",
-  "aws/chamber",
-  "aws/kops",
-  "aws/kops-aws-platform",
-  "aws/cloudtrail",
-]
+terraform_root_modules = {
+  "aws/tfstate-backend" => "/conf/tfstate-backend",
+  "aws/account-dns" => "/conf/account-dns",
+  "aws/chamber" => "/conf/chamber",
+  "aws/kops" => "/conf/kops",
+  "aws/kops-aws-platform" => "/conf/kops-aws-platform",
+  "aws/cloudtrail" => "/conf/cloudtrail",
+}

--- a/configs/staging.tfvars
+++ b/configs/staging.tfvars
@@ -41,7 +41,7 @@ templates = [
   "conf/kops-aws-platform/terraform.tfvars",
 ]
 
-# List of terraform root modules to enable
+# Map of terraform root modules to enable
 terraform_root_modules = {
   "aws/tfstate-backend"   = "/conf/tfstate-backend"
   "aws/account-dns"       = "/conf/account-dns"

--- a/configs/testing.tfvars
+++ b/configs/testing.tfvars
@@ -43,10 +43,10 @@ templates = [
 
 # List of terraform root modules to enable
 terraform_root_modules = {
-  "aws/tfstate-backend" => "/conf/tfstate-backend",
-  "aws/account-dns" => "/conf/account-dns",
-  "aws/chamber" => "/conf/chamber",
-  "aws/kops" => "/conf/kops",
-  "aws/kops-aws-platform" => "/conf/kops-aws-platform",
-  "aws/cloudtrail" => "/conf/cloudtrail",
+  "aws/tfstate-backend"   = "/conf/tfstate-backend"
+  "aws/account-dns"       = "/conf/account-dns"
+  "aws/chamber"           = "/conf/chamber"
+  "aws/kops"              = "/conf/kops"
+  "aws/kops-aws-platform" = "/conf/kops-aws-platform"
+  "aws/cloudtrail"        = "/conf/cloudtrail"
 }

--- a/configs/testing.tfvars
+++ b/configs/testing.tfvars
@@ -42,11 +42,11 @@ templates = [
 ]
 
 # List of terraform root modules to enable
-terraform_root_modules = [
-  "aws/tfstate-backend",
-  "aws/account-dns",
-  "aws/chamber",
-  "aws/kops",
-  "aws/kops-aws-platform",
-  "aws/cloudtrail",
-]
+terraform_root_modules = {
+  "aws/tfstate-backend" => "/conf/tfstate-backend",
+  "aws/account-dns" => "/conf/account-dns",
+  "aws/chamber" => "/conf/chamber",
+  "aws/kops" => "/conf/kops",
+  "aws/kops-aws-platform" => "/conf/kops-aws-platform",
+  "aws/cloudtrail" => "/conf/cloudtrail",
+}

--- a/configs/testing.tfvars
+++ b/configs/testing.tfvars
@@ -41,7 +41,7 @@ templates = [
   "conf/kops-aws-platform/terraform.tfvars",
 ]
 
-# List of terraform root modules to enable
+# Map of terraform root modules to enable
 terraform_root_modules = {
   "aws/tfstate-backend"   = "/conf/tfstate-backend"
   "aws/account-dns"       = "/conf/account-dns"

--- a/modules/account/main.tf
+++ b/modules/account/main.tf
@@ -1,9 +1,9 @@
 data "null_data_source" "terraform_root_modules" {
-  count = "${length(var.terraform_root_modules)}"
+  count = "${length(keys(var.terraform_root_modules))}"
 
   inputs = {
-    module_name = "${basename(element(var.terraform_root_modules, count.index))}"
-    copy_from   = "COPY --from=terraform-root-modules /${element(var.terraform_root_modules, count.index)}/ /conf/${basename(element(var.terraform_root_modules, count.index))}/"
+    module_name = "${element(values(var.terraform_root_modules), count.index)}"
+    copy_from   = "COPY --from=terraform-root-modules /${element(keys(var.terraform_root_modules), count.index)}/ /conf/${basename(element(values(var.terraform_root_modules), count.index))}/"
   }
 }
 

--- a/modules/account/main.tf
+++ b/modules/account/main.tf
@@ -3,7 +3,7 @@ data "null_data_source" "terraform_root_modules" {
 
   inputs = {
     module_name = "${element(values(var.terraform_root_modules), count.index)}"
-    copy_from   = "COPY --from=terraform-root-modules /${element(keys(var.terraform_root_modules), count.index)}/ /conf/${basename(element(values(var.terraform_root_modules), count.index))}/"
+    copy_from   = "COPY --from=terraform-root-modules /${element(keys(var.terraform_root_modules), count.index)}/ ${element(values(var.terraform_root_modules), count.index)}/"
   }
 }
 

--- a/modules/account/variables.tf
+++ b/modules/account/variables.tf
@@ -49,5 +49,5 @@ variable "docker_registry" {}
 variable "geodesic_base_image" {}
 
 variable "terraform_root_modules" {
-  type = "list"
+  type = "map"
 }

--- a/modules/child/variables.tf
+++ b/modules/child/variables.tf
@@ -66,5 +66,5 @@ variable "docker_registry" {}
 variable "geodesic_base_image" {}
 
 variable "terraform_root_modules" {
-  type = "list"
+  type = "map"
 }

--- a/modules/root/variables.tf
+++ b/modules/root/variables.tf
@@ -64,5 +64,5 @@ variable "docker_registry" {}
 variable "geodesic_base_image" {}
 
 variable "terraform_root_modules" {
-  type = "list"
+  type = "map"
 }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -84,8 +84,8 @@ function apply_modules() {
 			echo "Skipping ${module}..."
 		else
 			echo "Processing $module..."
-			direnv exec "/conf/${module}" make -C "/conf/${module}" deps
-			direnv exec "/conf/${module}" make -C "/conf/${module}" apply
+			direnv exec "${module}" make -C "${module}" deps
+			direnv exec "${module}" make -C "${module}" apply
 			if [ $? -ne 0 ]; then
 				abort "The ${module} module errored. Aborting."
 			fi


### PR DESCRIPTION
## what
* Support custom module paths


## why
* Support invocation of modules N times to multiple paths
* Support multi-region

e.g.
```
terraform_root_modules = {
  "/aws/chamber" => "/conf/us-west-2/chamber",
  "/aws/chamber" => "/conf/us-east-1/chamber"
}
```

## caveats
* Certain modules like `users` and `accounts` should be in `/conf` since they are global and not regional. Also `/conf/accounts` and `/conf/users` are hardcoded in places