### PR TITLE
Multiple updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ export DEFAULT_HELP_TARGET = help/short
 
 # The command we'll use to start the container 
 export DOCKER_RUN = docker run --rm --privileged -it -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e SSH_KEY=false \
-						-v $(CURDIR)/artifacts:/artifacts -v $(CURDIR)/scripts:/scripts
+						-v $(CURDIR)/artifacts:/artifacts -v $(CURDIR)/scripts:/scripts \
+						-v $(HOME):/localhost -e LOCAL_HOME=$(HOME)
 
 # The directory containing configs
 export CONFIGS ?= configs

--- a/configs/root.tfvars
+++ b/configs/root.tfvars
@@ -92,7 +92,7 @@ users = {
 
 # Geodesic Base Image (don't change this unless you know what you're doing)
 # Project: https://github.com/cloudposse/geodesic
-geodesic_base_image = "cloudposse/geodesic:0.87.0"
+geodesic_base_image = "cloudposse/geodesic:0.115.0"
 
 # List of terraform root modules to enable
 terraform_root_modules = [

--- a/modules/docker-build/main.tf
+++ b/modules/docker-build/main.tf
@@ -1,4 +1,11 @@
 resource "null_resource" "docker_build" {
+  # We have to acutally use the depends_on variable to make Terraform wait for the values to be finalized.
+  # Because the "depends_on" feature does not work with modules, this is the only way we have been
+  # able to get Terraform to wait for the file creation stage to finish before using the files.
+  provisioner "local-exec" {
+    command = "echo ${join(",",var.depends_on)} > /dev/null"
+  }
+
   provisioner "local-exec" {
     command     = "docker build -t ${var.image_name} -f ${var.dockerfile} ."
     working_dir = "${var.working_dir}"

--- a/modules/init-dirs/main.tf
+++ b/modules/init-dirs/main.tf
@@ -23,8 +23,9 @@ resource "null_resource" "touch" {
 
 resource "null_resource" "completed" {
   triggers {
-    # We do not care about the values, and in fact we do not want "depends_on" to change,
-    # but we do want and need to wait for the values to be availble.
-    depends_on = "${coalesce(null_resource.mkdir.id,null_resource.touch.id) == "" ? "false" : "true"}"
+    # We do not care about the values, this is just to force Terraform to wait for the values to be generate
+    id = "${null_resource.mkdir.id},${null_resource.touch.id}"
   }
+
+  depends_on = ["null_resource.touch"]
 }

--- a/modules/init-dirs/outputs.tf
+++ b/modules/init-dirs/outputs.tf
@@ -1,3 +1,3 @@
 output "completed" {
-  value = "${null_resource.completed.id == "" ? "false" : "true"}"
+  value = "${null_resource.completed.id}"
 }

--- a/modules/render/outputs.tf
+++ b/modules/render/outputs.tf
@@ -1,3 +1,4 @@
 output "completed" {
-  value = "${null_resource.completed.id == "" ? "false" : "true"}"
+  depends_on = ["null_resource.completed"]
+  value      = "${null_resource.completed.id}"
 }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -27,7 +27,7 @@ function assume_role() {
 	source /artifacts/.envrc
 
 	# Install the helper cli for assuming roles as part of the bootstrapping process
-	[ -x /usr/bin/assume-role ] || apk add assume-role@cloudposse
+	[ -x /usr/bin/assume-role ] || apk add --update assume-role@cloudposse
 
 	# This is because the [`assume-role`](https://github.com/remind101/assume-role) cli does not respect the SDK environment variables.
 	export HOME="/artifacts"
@@ -57,7 +57,7 @@ function assume_role() {
 function export_accounts() {
 	# Export account ids (for use with provisioning children)
 	cd /conf/accounts
-	direnv exec . make deps
+	direnv exec . make reset deps
 	(
 		echo "aws_account_ids = {"
 		terraform output -json | jq -r 'to_entries | .[] | .key + " = \"" + .value.value + "\""' | grep account_id | sed 's/_account_id//'

--- a/tasks/Makefile.root
+++ b/tasks/Makefile.root
@@ -4,8 +4,19 @@ root/clean:
 
 ## Initialize the "root" AWS account
 root/init: root/clean
-	$(DOCKER_RUN) cloudposse/geodesic:0.46.0 -c /scripts/get-root-account-id.sh
+	$(DOCKER_RUN) cloudposse/geodesic:0.96.0 -c /scripts/get-root-account-id.sh
 	terraform init -from-module=modules/root accounts/root
+	terraform apply \
+		-var-file=artifacts/aws.tfvars \
+		-var-file=$(CONFIGS)/root.tfvars \
+		-auto-approve \
+		-state=root.tfstate \
+		accounts/root
+	terraform output -state=root.tfstate docker_image > artifacts/root-docker-image
+
+# The init recipe can sometimes fail due to a race condition, in which case init-resume will
+# try to pick up where it left of. This is for manual use only.
+root/init-resume:
 	terraform apply \
 		-var-file=artifacts/aws.tfvars \
 		-var-file=$(CONFIGS)/root.tfvars \

--- a/templates/Dockerfile.child
+++ b/templates/Dockerfile.child
@@ -4,6 +4,17 @@
 
 FROM ${geodesic_base_image}
 
+# Terraform version changes should be carefully managed, but Geodesic updates them frequently,
+# so Terraform version should be pinned here and updated thoughfully.
+# Install terraform 0.11 for backwards compatibility
+RUN apk add terraform_0.11@cloudposse terraform@cloudposse==0.11.14-r0
+
+# helm and helmfile version changes should be carefully managed, but Geodesic updates them frequently,
+# so the versions should be pinned here and updated thoughfully.
+# Pin helm to 2.14.1 and helmfile to 0.73.1 for stability
+RUN apk add helm@cloudposse==2.14.1-r0 helmfile@cloudposse==0.73.1-r0
+
+
 ENV DOCKER_IMAGE="${docker_registry}/${image_name}"
 ENV DOCKER_TAG="${image_tag}"
 

--- a/templates/Dockerfile.root
+++ b/templates/Dockerfile.root
@@ -4,6 +4,12 @@
 
 FROM ${geodesic_base_image}
 
+# Terraform version changes should be carefully managed, but Geodesic updates them frequently,
+# so Terraform version should be pinned here and updated thoughfully.
+# Install terraform 0.11 for backwards compatibility
+RUN apk add terraform_0.11@cloudposse terraform@cloudposse==0.11.14-r0
+
+
 ENV DOCKER_IMAGE="${docker_registry}/${image_name}"
 ENV DOCKER_TAG="${image_tag}"
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -8,7 +8,7 @@ This repository provides all the tooling to manage the `${stage}` account infras
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | AWS Account ID | ${aws_account_id}                                                                                                             |
 | Account Email  | ${account_email_address}                                                                                                      |
-| Login URL      | <https://signin.aws.amazon.com/switchrole?account=${aws_account_id}&roleName=role_name&displayName=${namespace}-${stage}-admin> |
+| Login URL      | <https://signin.aws.amazon.com/switchrole?account=${aws_account_id}&roleName=OrganizationAccountAccessRole&displayName=${namespace}-${stage}-admin> |
 | Namespace      | ${namespace}                                                                                                                  |
 | Stage          | ${stage}                                                                                                                      |
 | Default Region | ${aws_region}                                                                                                                 |

--- a/templates/conf/account-dns/.envrc
+++ b/templates/conf/account-dns/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/account-settings/.envrc
+++ b/templates/conf/account-settings/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/accounts/.envrc
+++ b/templates/conf/accounts/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/audit-cloudtrail/.envrc
+++ b/templates/conf/audit-cloudtrail/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/backing-services/.envrc
+++ b/templates/conf/backing-services/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/bootstrap/.envrc
+++ b/templates/conf/bootstrap/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/chamber/.envrc
+++ b/templates/conf/chamber/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/cloudtrail/.envrc
+++ b/templates/conf/cloudtrail/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/helmfiles/helmfile.envrc
+++ b/templates/conf/helmfiles/helmfile.envrc
@@ -6,21 +6,21 @@ export HELMFILES_ARCHIVE=https://github.com/cloudposse/helmfiles/archive/0.43.0.
 export RBAC_ENABLED=true
 
 # The email address to receive notificaition about TLS certificates
-#export KUBE_LEGO_EMAIL=SETME
+# export KUBE_LEGO_EMAIL=devops+${STAGE}@example.com
  Set KUBE_LEGO_PROD to true to create production level TLS certificates, otherwise development level certificates are issued
 export KUBE_LEGO_PROD=true
 
 # The owner label to give DNS entries created by external-dns, typically the KOPS_CLUSTER_NAME
-export EXTERNAL_DNS_TXT_OWNER_ID=
+export EXTERNAL_DNS_TXT_OWNER_ID=${KOPS_CLUSTER_NAME}
 # A UUID for DNS entries created by external-dns
-export EXTERNAL_DNS_TXT_PREFIX=
+export EXTERNAL_DNS_TXT_PREFIX=${AWS_REGION}-${STAGE}-external-dns-managed
 # The IAM role external-dns should use
 export EXTERNAL_DNS_IAM_ROLE=${NAMESPACE}-${STAGE}-external-dns
 
 export NGINX_INGRESS_HOSTNAME=ingress.${KOPS_CLUSTER_NAME}
 export NGINX_INGRESS_KIND=DaemonSet
 # email address shown on nginx error pages
-#export NGINX_INGRESS_SUPPORT_EMAIL=SETME
+# export NGINX_INGRESS_SUPPORT_EMAIL=devops+${STAGE}@example.com
 
 # Autoscaling not necessary in the beginning
 export KOPS_CLUSTER_AUTOSCALER_ENABLED=false
@@ -34,6 +34,7 @@ export KUBERNETES_DASHBOARD_INGRESS_TLS_ENABLED=false
 # HOST is required if INGRESS is enabled
 #export KUBERNETES_DASHBOARD_INGRESS_HOST=
 
+# See prometheus.envrc for prometheus related config
 
 # installed modules (they default to true, but listed here in case you want to disable them temporarily)
 export RELOADER_INSTALLED=true
@@ -45,16 +46,6 @@ export EXTERNAL_DNS_INSTALLED=true
 export AWS_ALB_INGRESS_CONTROLLER_INSTALLED=true
 export KUBE_LEGO_INSTALLED=true
 export NGINX_INGRESS_INSTALLED=true
-
-# kube-prometheus components
-export KUBE_PROMETHEUS_INSTALLED=true
-export KUBE_PROMETHEUS_PUSH_GATEWAY_INSTALLED=true
-export KUBE_PROMETHEUS_PUSH_GATEWAY_MONITOR_INSTALLED=true
-export KUBE_PROMETHEUS_GRAFANA_INSTALLED=true
-
-# grafana components
-export GRAFANA_INSTALLED=true
-export GRAFANA_DB_INSTALLED=false
 
 # more installed modules
 export HEAPSTER_INSTALLED=true

--- a/templates/conf/helmfiles/helmfile.envrc
+++ b/templates/conf/helmfiles/helmfile.envrc
@@ -1,14 +1,14 @@
 # Best Practice: Replace "latest" with the version you want to use, so you control when you update helmfiles
 export HELMFILES_ARCHIVE=https://github.com/cloudposse/helmfiles/archive/latest.tar.gz
 
-export HELMFILES_ARCHIVE=https://github.com/cloudposse/helmfiles/archive/0.28.0.tar.gz
+export HELMFILES_ARCHIVE=https://github.com/cloudposse/helmfiles/archive/0.43.0.tar.gz
 
 export RBAC_ENABLED=true
 
 # The email address to receive notificaition about TLS certificates
 #export KUBE_LEGO_EMAIL=SETME
  Set KUBE_LEGO_PROD to true to create production level TLS certificates, otherwise development level certificates are issued
-export KUBE_LEGO_PROD=false
+export KUBE_LEGO_PROD=true
 
 # The owner label to give DNS entries created by external-dns, typically the KOPS_CLUSTER_NAME
 export EXTERNAL_DNS_TXT_OWNER_ID=
@@ -22,12 +22,11 @@ export NGINX_INGRESS_KIND=DaemonSet
 # email address shown on nginx error pages
 #export NGINX_INGRESS_SUPPORT_EMAIL=SETME
 
+# Autoscaling not necessary in the beginning
+export KOPS_CLUSTER_AUTOSCALER_ENABLED=false
+
 # IAM role for aws alb ingress controller
 export AWS_ALB_INGRESS_CONTROLLER_IAM_ROLE_NAME=${NAMESPACE}-${STAGE}-alb-ingress
-
-export GRAFANA_INGRESS_ENABLED=false
-# GRAFANA_HOSTNAME is required if INGRESS is enabled
-#export GRAFANA_HOSTNAME=
 
 
 export KUBERNETES_DASHBOARD_INGRESS_ENABLED=false
@@ -39,6 +38,7 @@ export KUBERNETES_DASHBOARD_INGRESS_TLS_ENABLED=false
 # installed modules (they default to true, but listed here in case you want to disable them temporarily)
 export RELOADER_INSTALLED=true
 export CERT_MANAGER_INSTALLED=true
+export CLUSTER_AUTOSCALER_INSTALLED=false
 export PROMETHEUS_OPERATOR_INSTALLED=true
 export KIAM_INSTALLED=true
 export EXTERNAL_DNS_INSTALLED=true
@@ -54,7 +54,7 @@ export KUBE_PROMETHEUS_GRAFANA_INSTALLED=true
 
 # grafana components
 export GRAFANA_INSTALLED=true
-export GRAFANA_DB_INSTALLED=true
+export GRAFANA_DB_INSTALLED=false
 
 # more installed modules
 export HEAPSTER_INSTALLED=true

--- a/templates/conf/helmfiles/helmfile.yaml
+++ b/templates/conf/helmfiles/helmfile.yaml
@@ -1,11 +1,12 @@
 # Ordered list of releases. 
 helmfiles:
+  - "releases/reloader.yaml"
+  - "releases/cert-manager.yaml"
   - "releases/prometheus-operator.yaml"
   - "releases/kiam.yaml"
   - "releases/external-dns.yaml"
+  - "releases/aws-alb-ingress-controller.yaml"
   - "releases/kube-lego.yaml"
   - "releases/nginx-ingress.yaml"
-  - "releases/kube-prometheus.yaml"
-  - "releases/grafana.yaml"
   - "releases/heapster.yaml"
   - "releases/dashboard.yaml"

--- a/templates/conf/helmfiles/prometheus.envrc
+++ b/templates/conf/helmfiles/prometheus.envrc
@@ -1,0 +1,34 @@
+export PROMETHEUS_OPERATOR_INSTALLED=true
+
+# HTTPS does not work, see See https://github.com/coreos/prometheus-operator/issues/926
+export PROMETHEUS_KUBELET_HTTPS=false
+# Some installations use a label name of "component", and it is the chart default, but kops uses "k8s-app"
+export PROMETHEUS_KUBE_K8S_APP_LABEL_NAME=true
+
+# Configuration file, relative to releases/ directory
+# export PROMETHEUS_ADDITIONAL_CONFIG_YAML="../prometheus-config.yaml"
+export PROMETHEUS_PROMETHEUS_EXTERNAL_URL="https://prometheus.${KOPS_CLUSTER_NAME}/"
+
+# Set according to whether the cluster is using kubeDNS or CoreDNS
+export PROMETHEUS_EXPORTER_CORE_DNS_ENABLED=true
+export PROMETHEUS_EXPORTER_KUBE_DNS_ENABLED=false
+# This allows people to use Grafana without requiring we give them an account
+export PROMETHEUS_ANONYMOUS_ADMIN_ENABLED=true
+
+export GRAFANA_INSTALLED=true
+export GRAFANA_INGRESS_ENABLED=false
+# GRAFANA_HOSTNAME is required if INGRESS is enabled
+#export GRAFANA_HOSTNAME=
+export PROMETHEUS_GRAFANA_ROOT_URL="https://grafana.${KOPS_CLUSTER_NAME}/"
+
+export PROMETHEUS_ALERTMANAGER_EXTERNAL_URL="https://alertmanager.${KOPS_CLUSTER_NAME}/"
+
+## Disable older, conflicting stuff
+# kube-prometheus components
+export KUBE_PROMETHEUS_INSTALLED=false
+export KUBE_PROMETHEUS_PUSH_GATEWAY_INSTALLED=false
+export KUBE_PROMETHEUS_PUSH_GATEWAY_MONITOR_INSTALLED=false
+export KUBE_PROMETHEUS_GRAFANA_INSTALLED=false
+
+# kube-prometheus alerts managers components
+#export KUBE_PROMETHEUS_ALERT_MANAGER_SLACK_CHANNEL=

--- a/templates/conf/iam/.envrc
+++ b/templates/conf/iam/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/kops-aws-platform/.envrc
+++ b/templates/conf/kops-aws-platform/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/kops/.envrc
+++ b/templates/conf/kops/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/kops/kops.envrc
+++ b/templates/conf/kops/kops.envrc
@@ -1,2 +1,11 @@
-export KOPS_TEMPLATE_VERSION=0.6.0
+export KOPS_TEMPLATE_VERSION=0.11.0
 export KOPS_TEMPLATE=https://raw.githubusercontent.com/cloudposse/reference-architectures/$${KOPS_TEMPLATE_VERSION}/templates/kops/kops-private-topology.yaml.gotmpl
+
+export KOPS_MANIFEST=./manifest.yaml
+
+export KUBERNETES_VERSION=1.12.9
+export KOPS_BASE_IMAGE=kope.io/k8s-1.12-debian-stretch-amd64-hvm-ebs-2019-05-13
+export KOPS_AUTHORIZATION_RBAC_ENABLED=true
+
+export NODE_MIN_SIZE=3
+export NODE_MAX_SIZE=3

--- a/templates/conf/kops/terraform.envrc
+++ b/templates/conf/kops/terraform.envrc
@@ -1,2 +1,2 @@
-export TF_CLI_INIT_FROM_MODULE="git::https://github.com/cloudposse/terraform-root-modules.git//aws/kops?ref=tags/0.61.0"
+export TF_CLI_INIT_FROM_MODULE="git::https://github.com/cloudposse/terraform-root-modules.git//aws/kops?ref=tags/0.68.0"
 export TF_CLI_PLAN_PARALLELISM=2

--- a/templates/conf/root-dns/.envrc
+++ b/templates/conf/root-dns/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/root-iam/.envrc
+++ b/templates/conf/root-iam/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/tfstate-backend/.envrc
+++ b/templates/conf/tfstate-backend/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv

--- a/templates/conf/users/.envrc
+++ b/templates/conf/users/.envrc
@@ -1,4 +1,4 @@
 use envrc
-use terraform
+use terraform 0.11
 use atlantis
 use tfenv


### PR DESCRIPTION
## what
- Update to more recent versions of kops, Kubernetes, helm, helmfile, while pinning versions
- Enable use of shared VPC
- Fix race condition in creation of Docker images
- Update helmfile configuration to use `prometheus-operator`
- Update Geodesic version
## why
- Get recent enhancements and bug fixes
- Allow kops cluster to be provisioned inside existing VPC, avoiding the need for VPC peering in some cases
- Makes would break because the `docker build` command would be issued before all the files were finished being created and updated.
- Old Geodesic lacked features we now need, like supporting multiple versions of `terraform`