### PR TITLE
[codefresh][helmfiles] Add Codefresh pipeline, update helmfiles pattern

### DIFF
--- a/codefresh/build-aws-env-tools.yml
+++ b/codefresh/build-aws-env-tools.yml
@@ -1,0 +1,97 @@
+# Build a Geodesic image customized for an AWS environment
+version: '1.0'
+
+stages:
+  - Prepare
+  - Build
+  - Push
+
+steps:
+  validate:
+    title: "Validate"
+    description: "Ensure build parameters are present"
+    stage: Prepare
+    image: codefresh/cli:latest
+    commands:
+      - echo DOCKER_REGISTRY must be set to the name of the Codefresh Docker Registry integration to push the image to
+      - echo Required parameter missing. See above. 1>&2
+      - codefresh terminate ${{CF_BUILD_ID}}
+    when:
+      condition:
+        any:
+          # If a variable is not defined, then ${{variable}} is not substituted and the literal string is used
+          # So if the variable substitution includes the variable name, we conclude that it was not set.
+          docker_registry_missing: 'includes("${{DOCKER_REGISTRY}}", "DOCKER_REGISTRY") == true'
+
+  main_clone:
+    title: "Clone repository"
+    type: git-clone
+    stage: Prepare
+    description: "Initialize"
+    repo: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
+    git: CF-default
+    revision: ${{CF_REVISION}}
+
+  build_image:
+    title: Build image
+    type: build
+    stage: Build
+    description: Build geodesic
+    image_name: ${{CF_REPO_NAME}}
+    dockerfile: Dockerfile
+
+  push_image_commit:
+    title: Push image with commit sha tag
+    type: push
+    stage: Push
+    candidate: ${{build_image}}
+    image_name: ${{CF_REPO_NAME}}
+    registry: ${{DOCKER_REGISTRY}}
+    tags:
+      - "${{CF_REVISION}}"
+      - "${{CF_SHORT_REVISION}}"
+
+  push_image_branch:
+    title: Push image with branch tag
+    type: push
+    stage: Push
+    candidate: ${{build_image}}
+    image_name: ${{CF_REPO_NAME}}
+    registry: ${{DOCKER_REGISTRY}}
+    tags:
+      - "${{CF_BRANCH_TAG_NORMALIZED}}"
+    when:
+      condition:
+        all:
+          execute_for_branch: "'${{CF_BRANCH}}' != ''"
+          branch_not_missing: 'includes("${{CF_BRANCH}}", "CF_BRANCH") == false'
+
+  push_image_pull_request:
+    title: Push image with pull request tag
+    type: push
+    stage: Push
+    candidate: ${{build_image}}
+    image_name: ${{CF_REPO_NAME}}
+    registry: ${{DOCKER_REGISTRY}}
+    tags:
+      - "pr-${{CF_PULL_REQUEST_NUMBER}}"
+    when:
+      condition:
+        all:
+          pr_num_not_missing: 'includes("${{CF_PULL_REQUEST_NUMBER}}", "CF_PULL_REQUEST_NUMBER") == false'
+
+  push_image_release:
+    title: Push image with release tag
+    type: push
+    stage: Push
+    candidate: ${{build_image}}
+    image_name: ${{CF_REPO_NAME}}
+    registry: ${{DOCKER_REGISTRY}}
+    tags:
+      - "${{CF_RELEASE_TAG}}"
+      - latest
+    when:
+      condition:
+        all:
+          release_tag_present: 'includes("${{CF_RELEASE_TAG}}", "CF_RELEASE_TAG") == false'
+

--- a/codefresh/build.yml
+++ b/codefresh/build.yml
@@ -7,21 +7,6 @@ stages:
   - Push
 
 steps:
-  validate:
-    title: "Validate"
-    description: "Ensure build parameters are present"
-    stage: Prepare
-    image: codefresh/cli:latest
-    commands:
-      - echo DOCKER_REGISTRY must be set to the name of the Codefresh Docker Registry integration to push the image to
-      - echo Required parameter missing. See above. 1>&2
-      - codefresh terminate ${{CF_BUILD_ID}}
-    when:
-      condition:
-        any:
-          # If a variable is not defined, then ${{variable}} is not substituted and the literal string is used
-          # So if the variable substitution includes the variable name, we conclude that it was not set.
-          docker_registry_missing: 'includes("${{DOCKER_REGISTRY}}", "DOCKER_REGISTRY") == true'
 
   main_clone:
     title: "Clone repository"

--- a/templates/conf/helmfiles/Makefile
+++ b/templates/conf/helmfiles/Makefile
@@ -1,7 +1,6 @@
 ## Fetch the remote helmfiles
 deps:
-	curl -sSL -q  $(HELMFILES_ARCHIVE)  --output - | tar -xz  --strip-components=1 --wildcards "*/releases" "*/scripts"
-
+	@exit 0
 
 diff: kubeconfig
 	chamber exec kops -- helmfile diff --args="--allow-unreleased --context 5 --no-color --suppress-secrets"
@@ -16,15 +15,7 @@ reset:
 
 ## Install or upgrade tiller. Should only be needed when initially creating the environment.
 install-tiller upgrade-tiller: kubeconfig
-	if [[ $$RBAC_ENABLED == "true" ]]; then \
-		kubectl get -n kube-system serviceaccount tiller > /dev/null 2>&1 || \
-		kubectl -n kube-system create serviceaccount tiller ; \
-		kubectl get -n kube-system clusterrolebinding tiller > /dev/null 2>&1 || \
-		kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller ;\
-		helm init --history-max 200 --service-account tiller --upgrade; \
-	else \
-		helm init --history-max 200 --upgrade ; \
-	fi
+	helmctl tiller install
 
 .PHONY: kubeconfig
 kubeconfig:

--- a/templates/conf/helmfiles/helmfile.yaml
+++ b/templates/conf/helmfiles/helmfile.yaml
@@ -1,12 +1,12 @@
 # Ordered list of releases. 
 helmfiles:
-  - "releases/reloader.yaml"
-  - "releases/cert-manager.yaml"
-  - "releases/prometheus-operator.yaml"
-  - "releases/kiam.yaml"
-  - "releases/external-dns.yaml"
-  - "releases/aws-alb-ingress-controller.yaml"
-  - "releases/kube-lego.yaml"
-  - "releases/nginx-ingress.yaml"
-  - "releases/heapster.yaml"
-  - "releases/dashboard.yaml"
+  - path: git::https://github.com/cloudposse/helmfiles.git@releases/reloader.yaml?ref=0.43.0
+  - path: git::https://github.com/cloudposse/helmfiles.git@releases/cert-manager.yaml?ref=0.43.0
+  - path: git::https://github.com/cloudposse/helmfiles.git@releases/prometheus-operator.yaml?ref=0.43.0
+  - path: git::https://github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.43.0
+  - path: git::https://github.com/cloudposse/helmfiles.git@releases/external-dns.yaml?ref=0.43.0
+  - path: git::https://github.com/cloudposse/helmfiles.git@releases/aws-alb-ingress-controller.yaml?ref=0.43.0
+  - path: git::https://github.com/cloudposse/helmfiles.git@releases/kube-lego.yaml?ref=0.43.0
+  - path: git::https://github.com/cloudposse/helmfiles.git@releases/nginx-ingress.yaml?ref=0.43.0
+  - path: git::https://github.com/cloudposse/helmfiles.git@releases/heapster.yaml?ref=0.43.0
+  - path: git::https://github.com/cloudposse/helmfiles.git@releases/dashboard.yaml?ref=0.43.0


### PR DESCRIPTION
## what
1. [codefresh] Add a Codefresh pipeline to automatically build AWS Environment tools Docker images.
1. [helmfiles] Update to current pattern of pinning helmfiles to versions individually
1. [helmfiles] Use `helmctl` from Geodesic image rather than complicated `make` recipe.
## why
1. Enable automatic building of Docker images so everyone can easily have access to up-to-date versions.
1. Provide the ability to upgrade one helmfile to a newer version while leaving others unchanged.
1. Reduce code duplication.