### PR TITLE
[codefresh] Require user to specify Git provider

### DIFF
--- a/codefresh/build.yml
+++ b/codefresh/build.yml
@@ -14,7 +14,7 @@ steps:
     stage: Prepare
     description: "Initialize"
     repo: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
-    git: CF-default
+    git: ${{GIT_PROVIDER}}
     revision: ${{CF_REVISION}}
 
   build_image:


### PR DESCRIPTION
## what
[codefresh] Require user to specify Git provider

## why
Codefresh dropped support for using `CF-default` as a default Git provider, now requires one to be explicitly configured. 