### PR TITLE
[kops] Expose kube-proxy metrics endpoint to the cluster

### DIFF
--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -210,6 +210,8 @@ spec:
   kubelet:
     anonymousAuth: false
 {{- end }}
+  kubeProxy:
+    metricsBindAddress: 0.0.0.0
   kubernetesApiAccess:
   {{- range (getenv "KOPS_KUBERNETES_API_ACCESS" | default "0.0.0.0/0" | strings.Split ",") }}
   - {{ . }}


### PR DESCRIPTION
## what

In `kops-private-topology.yaml.gotmpl`, add a setting for `kube-proxy` to enable metrics endpoint on all IP addresses

## why

By default, `kube-proxy` only enables the metrics endpoint on `localhost`, but `prometheus` cannot access it that way. This change allows `prometheus` to gather metrics from `kube-proxy`.