### PR TITLE
[kops-private-topology] Align with current auto-scaler implementation

### DIFF
--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -32,19 +32,6 @@ spec:
                "ec2:DescribeTags"
            ],
            "Resource": "*"
-        {{- if bool (getenv "KOPS_CLUSTER_AUTOSCALER_ENABLED" "false") }}
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeAutoScalingInstances",
-                "autoscaling:DescribeTags",
-                "autoscaling:SetDesiredCapacity",
-                "autoscaling:TerminateInstanceInAutoScalingGroup"
-            ],
-            "Resource": "*"
-        {{- end }}
         }
       ]
   api:
@@ -94,7 +81,7 @@ spec:
     Cluster: {{ getenv "KOPS_CLUSTER_NAME" }}
     {{- if bool (getenv "KOPS_CLUSTER_AUTOSCALER_ENABLED" "false") }}
     k8s.io/cluster-autoscaler/enabled: "true"
-    kubernetes.io/cluster/{{ getenv "KOPS_CLUSTER_NAME" }}: "owned"
+    k8s.io/cluster-autoscaler/{{ getenv "KOPS_CLUSTER_NAME" }}: "owned"
     {{- end }}
   cloudProvider: aws
   configBase: {{ getenv "KOPS_STATE_STORE" }}/{{ getenv "KOPS_CLUSTER_NAME" }}

--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -311,6 +311,33 @@ spec:
   - {{ . }}
 {{- end }}
 
+{{- if getenv "NODE_MAX_SIZE_PER_AZ" }}
+{{ range (getenv "KOPS_NODES_AVAILABILITY_ZONES" ( getenv "KOPS_AVAILABILITY_ZONES" ) | strings.Split ",") }}
+---
+apiVersion: kops/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: {{ getenv "KOPS_CLUSTER_NAME" }}
+  name: nodes-{{ . }}
+spec:
+  detailedInstanceMonitoring: {{ getenv "KOPS_CLOUDWATCH_DETAILED_MONITORING" "false" }}
+  associatePublicIp: false
+  {{- if bool (getenv "KOPS_CLUSTER_AUTOSCALER_ENABLED" "false") }}
+  cloudLabels:
+    k8s.io/cluster-autoscaler/enabled: "true"
+    k8s.io/cluster-autoscaler/{{ getenv "KOPS_CLUSTER_NAME" }}: "owned"
+  {{- end }}
+  image: {{ getenv "KOPS_BASE_IMAGE" }}
+  machineType: {{ getenv "NODE_MACHINE_TYPE" }}
+  maxSize: {{ getenv "NODE_MAX_SIZE_PER_AZ" }}
+  minSize: {{ getenv "NODE_MIN_SIZE_PER_AZ" "1" }}
+  role: Node
+  subnets:
+  - {{ . }}
+{{- end }}
+
+{{- else }}
 ---
 apiVersion: kops/v1alpha2
 kind: InstanceGroup
@@ -335,6 +362,7 @@ spec:
   {{- range (getenv "KOPS_NODES_AVAILABILITY_ZONES" ( getenv "KOPS_AVAILABILITY_ZONES" ) | strings.Split ",") }}
   - {{ . }}
   {{- end }}
+{{- end }}
 
 {{/* Allow the manifest to be extended via a datasource */}}
 {{- if (datasourceExists "extensions") -}}

--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -79,10 +79,6 @@ spec:
   channel: stable
   cloudLabels:
     Cluster: {{ getenv "KOPS_CLUSTER_NAME" }}
-    {{- if bool (getenv "KOPS_CLUSTER_AUTOSCALER_ENABLED" "false") }}
-    k8s.io/cluster-autoscaler/enabled: "true"
-    k8s.io/cluster-autoscaler/{{ getenv "KOPS_CLUSTER_NAME" }}: "owned"
-    {{- end }}
   cloudProvider: aws
   configBase: {{ getenv "KOPS_STATE_STORE" }}/{{ getenv "KOPS_CLUSTER_NAME" }}
   {{- if getenv "KOPS_DNS_ZONE" }}
@@ -325,6 +321,11 @@ metadata:
 spec:
   detailedInstanceMonitoring: {{ getenv "KOPS_CLOUDWATCH_DETAILED_MONITORING" "false" }}
   associatePublicIp: false
+  {{- if bool (getenv "KOPS_CLUSTER_AUTOSCALER_ENABLED" "false") }}
+  cloudLabels:
+    k8s.io/cluster-autoscaler/enabled: "true"
+    k8s.io/cluster-autoscaler/{{ getenv "KOPS_CLUSTER_NAME" }}: "owned"
+  {{- end }}
   image: {{ getenv "KOPS_BASE_IMAGE" }}
   machineType: {{ getenv "NODE_MACHINE_TYPE" }}
   maxSize: {{ getenv "NODE_MAX_SIZE" }}


### PR DESCRIPTION
## what
In [kops-private-topology] template:
1. Remove IAM permissions previously added to nodes to allow them to perform autoscaling
1. Move autoscaling auto-discovery `cloudLabels` from `kubeAPIServer` to `InstanceGroup` for `nodes`
1. Allow creation of 1 node instance group per availability zone rather than only 1 across all zones

## why
1. Autoscaler should be enabled via IAM role administered by `kiam`, not statically on all nodes
1. Sync with current [autoscaler chart v3.2.0](https://github.com/helm/charts/tree/e975982bcbb4bda8d747229c2d5a73d939f0b4e6/stable/cluster-autoscaler) 
1. Enable autoscaler to place new instances in zones that need them