### PR TITLE
Adds featureGates to already templated services

### DIFF
--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -44,6 +44,12 @@ spec:
     anonymousAuth: false
     authorizationMode: {{ getenv "KOPS_KUBE_API_SERVER_AUTHORIZATION_MODE" "RBAC" }}
   {{- end }}
+  {{- if bool (getenv "KOPS_KUBE_API_SERVER_FEATURE_GATES_ENABLED" "false") }}
+    featureGates:
+      {{- range $feature := strings.Split " " (getenv "KOPS_KUBE_API_SERVER_ENABLED_FEATURES" "") }}
+      {{ $feature }}: true
+      {{- end }}
+  {{- end }}
   {{- if bool (getenv "KOPS_ADMISSION_CONTROL_ENABLED" "true") }}
     admissionControl:
     - NamespaceLifecycle

--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -219,8 +219,20 @@ spec:
     # Workloads that do not want CPU throttling can opt out by not specifying CPU limits.
     cpuCFSQuota: false
     {{- end }}
+    {{- if gt (len (getenv "KOPS_KUBE_KUBELET_FEATURE_GATES" "")) 0 }}
+    featureGates:
+    {{- range $feature := strings.Split "," (getenv "KOPS_KUBE_KUBELET_FEATURE_GATES" "") }}
+      {{ $feature | strings.ReplaceAll "=" ": " }}
+    {{- end }}
+    {{- end }}
   kubeProxy:
     metricsBindAddress: 0.0.0.0
+    {{- if gt (len (getenv "KOPS_KUBE_PROXY_FEATURE_GATES" "")) 0 }}
+    featureGates:
+    {{- range $feature := strings.Split "," (getenv "KOPS_KUBE_PROXY_FEATURE_GATES" "") }}
+      {{ $feature | strings.ReplaceAll "=" ": " }}
+    {{- end }}
+    {{- end }}
   kubernetesApiAccess:
   {{- range (getenv "KOPS_KUBERNETES_API_ACCESS" | default "0.0.0.0/0" | strings.Split ",") }}
   - {{ . }}

--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -44,14 +44,11 @@ spec:
     anonymousAuth: false
     authorizationMode: {{ getenv "KOPS_KUBE_API_SERVER_AUTHORIZATION_MODE" "RBAC" }}
   {{- end }}
-  {{- if or (gt (len (getenv "KOPS_KUBE_API_SERVER_ENABLED_FEATURES" "")) 0) (gt (len (getenv "KOPS_KUBE_API_SERVER_DISABLED_FEATURES" "")) 0) }}
+  {{- if gt (len (getenv "KOPS_KUBE_API_SERVER_FEATURE_GATES" "")) 0 }}
     featureGates:
-      {{- range $feature := strings.Split "," (getenv "KOPS_KUBE_API_SERVER_ENABLED_FEATURES" "") }}
-      {{ if gt (len $feature) 0 }}{{ $feature }}: true{{ end }}
-      {{- end }}
-      {{- range $feature := strings.Split "," (getenv "KOPS_KUBE_API_SERVER_DISABLED_FEATURES" "") }}
-      {{ if gt (len $feature) 0 }}{{ $feature }}: false{{ end }}
-      {{- end }}
+    {{- range $feature := strings.Split "," (getenv "KOPS_KUBE_API_SERVER_FEATURE_GATES" "") }}
+      {{ $feature | strings.ReplaceAll "=" ": " }}
+    {{- end }}
   {{- end }}
   {{- if bool (getenv "KOPS_ADMISSION_CONTROL_ENABLED" "true") }}
     admissionControl:

--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -44,10 +44,13 @@ spec:
     anonymousAuth: false
     authorizationMode: {{ getenv "KOPS_KUBE_API_SERVER_AUTHORIZATION_MODE" "RBAC" }}
   {{- end }}
-  {{- if bool (getenv "KOPS_KUBE_API_SERVER_FEATURE_GATES_ENABLED" "false") }}
+  {{- if or (gt (len (getenv "KOPS_KUBE_API_SERVER_ENABLED_FEATURES" "")) 0) (gt (len (getenv "KOPS_KUBE_API_SERVER_DISABLED_FEATURES" "")) 0) }}
     featureGates:
-      {{- range $feature := strings.Split " " (getenv "KOPS_KUBE_API_SERVER_ENABLED_FEATURES" "") }}
-      {{ $feature }}: true
+      {{- range $feature := strings.Split "," (getenv "KOPS_KUBE_API_SERVER_ENABLED_FEATURES" "") }}
+      {{ if gt (len $feature) 0 }}{{ $feature }}: true{{ end }}
+      {{- end }}
+      {{- range $feature := strings.Split "," (getenv "KOPS_KUBE_API_SERVER_DISABLED_FEATURES" "") }}
+      {{ if gt (len $feature) 0 }}{{ $feature }}: false{{ end }}
       {{- end }}
   {{- end }}
   {{- if bool (getenv "KOPS_ADMISSION_CONTROL_ENABLED" "true") }}


### PR DESCRIPTION
## what
* Allows kops to configure feature gates on the kubernetes API server, kubelet, and kube-proxy
* Will look for `KOPS_KUBE_API_SERVER_FEATURE_GATES` as a comma separated list of `key=value` pairs for kube api server
* kubelet looks for `KOPS_KUBE_KUBELET_FEATURE_GATES`
* kubeproxy looks for `KOPS_KUBE_PROXY_FEATURE_GATES`

Of note, I did not add support for scheduler or controller manager since you're currently not deviating from defaults there.  I could add those if you'd like.

Also of note: I don't do error checking on input formatting here, as I felt it would overly complicate the template.  I'm also not sure the best way to do that, so there's also that.  Things will fail if the environment variables are not set as `feature1="false",feature2="true"` and so on.

## why
* to enable/disable alpha and beta features

## example parsing
```bash
$ gomplate -f /localhost/work/cloudposse/reference-architectures/templates/kops/kops-private-topology.yaml.gotmpl | grep -C5 feature
# no output, note added for clarity
$ export KOPS_KUBE_API_SERVER_FEATURE_GATES="ExpandInUsePersistentVolumes=true,SomeOtherFeature=false"
$ gomplate -f /localhost/work/cloudposse/reference-architectures/templates/kops/kops-private-topology.yaml.gotmpl | grep -C5 feature
      type: Public
      idleTimeoutSeconds: 600
  kubeAPIServer:
    anonymousAuth: false
    authorizationMode: RBAC
    featureGates:
      ExpandInUsePersistentVolumes: true
      SomeOtherFeature: false
    admissionControl:
    - NamespaceLifecycle
    - LimitRanger
```

## references
* https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features
* https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#feature-gates