### PR TITLE
[kops/template] Fix kops install hook that installs iptable rule for kiam

### DIFF
--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -137,14 +137,22 @@ spec:
   # Install iptable entry for kiam which, when kiam is not present, will prevent any access to EC2 metadata
   # NOTE: the interface name (after -i) must be the same as the interface name passed to kiam
   #       and if kiam is not listening on the default 8181 port, you must replace 8181 with the correct port number
-  - after:
-    - network.target
+  - name: kiam-iptables.service
     manifest: |
+      [Unit]
+      Description=Install iptables rule to divert all credential requests to kiam
+      Wants=network-online.target
+      After=network-online.target
+      Before=docker.service
+
+      [Service]
       Type=oneshot
       ExecStart=/bin/sh -c '/sbin/iptables -t nat -A PREROUTING -d 169.254.169.254/32 \
-          -i cali+ -p tcp -m tcp --dport 80 -j DNAT \
-          --to-destination $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4):8181'
-    name: kiam-iptables.service
+        -i cali+ -p tcp -m tcp --dport 80 -j DNAT \
+        --to-destination $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4):8181'
+      RemainAfterExit=yes
+
+    useRawManifest: true
     roles: [Node]
 {{- end }}
 {{- if getenv "TELEPORT_PROXY_DOMAIN_NAME" }}


### PR DESCRIPTION
## what
[kops-private-topology.yaml.gotmpl] Fix `kops` install hook that installs iptable rule for kiam.

## why
Although we have not experienced problems with the prior hook, `kops` does not actually support an `after` clause and we were using the wrong `after` clause anyway. This new hook installs a systemd unit that properly waits for the network to come up fully (in particular, we need it to be assigned an IP address) and also gets run before Docker starts bringing up containers. 

## references
This hook is needed to free `kiam` from the responsibility of managing `iptables` itself, which in turn allows for RollingUpdates. See https://github.com/uswitch/kiam/issues/202 and  https://github.com/uswitch/kiam/pull/253