### PR TITLE
Support kubelet authenticationTokenWebhook

### DIFF
--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -218,6 +218,7 @@ spec:
   kubelet:
     {{- if bool (getenv "KOPS_AUTHORIZATION_RBAC_ENABLED" "false") }}
     anonymousAuth: false
+    authenticationTokenWebhook: true
     {{- end }}
     {{- if getenv "KOPS_CPU_CFS_QUOTA_PERIOD" }}
     # cpuCFSQuotaPeriod sets CPU CFS quota period value.

--- a/templates/kops/kops-private-topology.yaml.gotmpl
+++ b/templates/kops/kops-private-topology.yaml.gotmpl
@@ -218,6 +218,8 @@ spec:
   kubelet:
     {{- if bool (getenv "KOPS_AUTHORIZATION_RBAC_ENABLED" "false") }}
     anonymousAuth: false
+    {{- end }}
+    {{- if bool (getenv "KOPS_KUBELET_AUTHENTICATION_TOKEN_WEBHOOK_ENABLED" "false") }}    
     authenticationTokenWebhook: true
     {{- end }}
     {{- if getenv "KOPS_CPU_CFS_QUOTA_PERIOD" }}


### PR DESCRIPTION
## What
* Added support `authenticationTokenWebhook` for kubelet

## Why
* Required by metrics server for HPA